### PR TITLE
Revert "ci/connected-checks"

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,11 +28,6 @@ jobs:
       run: ./gradlew build
     - name: Unit tests
       run: ./gradlew check
-    - name: Instrumental Tests
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 26
-        script: ./gradlew connectedCheck
     - name: Save Test Reports
       uses: actions/upload-artifact@v2
       if: always()


### PR DESCRIPTION
Reverts Segelzwerg/FamilyFotoAndroid#18

test are still failing. coverage can be done manually for now